### PR TITLE
Fix head command usage on OSX

### DIFF
--- a/ovshapi
+++ b/ovshapi
@@ -93,8 +93,8 @@ duration=$(jq -r .time <<< $status)
 
 if [[ "$code" != "200" ]]; then
   >&2 echo -e "\033[31mERROR:\033[m: $code on $1 $2"
-  echo "$response" | head -n -1
+  echo "$response" | head -n 1
   exit 1
 fi
 
-echo "$response" | head -n -1 | jq -c .
+echo "$response" | head -n 1 | jq -c .


### PR DESCRIPTION
The default head provided in OSX does not comply with the "-1" argument.
What we want to do here seems to be similar to running "head -n 1" directly, which
fixes the usage on OSX.